### PR TITLE
Add new device type code for SH10RT-V112.

### DIFF
--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -992,15 +992,17 @@ template:
         {% elif ((states('sensor.sungrow_device_type_code') | int(default=0)) == 0x0D0B) %}
           SH4K6-30
         {% elif ((states('sensor.sungrow_device_type_code') | int(default=0)) == 0x0D0F) %}
-          SH5.0RS            
+          SH5.0RS
         {% elif ((states('sensor.sungrow_device_type_code') | int(default=0)) == 0x0D0D) %}
           SH3.6RS
         {% elif ((states('sensor.sungrow_device_type_code') | int(default=0)) == 0x0D0E) %}
           SH4.6RS
         {% elif ((states('sensor.sungrow_device_type_code') | int(default=0)) == 0x0D10) %}
-          SH6.0RS                                                                                              
+          SH6.0RS
         {% elif ((states('sensor.sungrow_device_type_code') | int(default=0)) == 0x0E03) %}
           SH10RT
+        {% elif ((states('sensor.sungrow_device_type_code') | int(default=0)) == 0x0E0F) %}
+          SH10RT-V112
         {% elif ((states('sensor.sungrow_device_type_code') | int(default=0)) == 0x0E02) %}
           SH8.0RT
         {% elif ((states('sensor.sungrow_device_type_code') | int(default=0)) == 0x0E01) %}


### PR DESCRIPTION
My new SH10RT has an new type code of 0E0F and was not covered yet. With this change it will show the same 'Device Model' name as in the iSolarCloud device information page.

![grafik](https://user-images.githubusercontent.com/16257592/208297079-be236795-4669-4906-9271-64dae426870a.png)

![grafik](https://user-images.githubusercontent.com/16257592/208297120-68892586-4011-44c6-94fa-77d849510c87.png)
