### PR TITLE
backup power and reading from the meter added

### DIFF
--- a/PV_Info.yaml
+++ b/PV_Info.yaml
@@ -3,8 +3,9 @@ views:
     cards:
       - type: entities
         entities:
-          - entity: sensor.total_dc_power
           - entity: sensor.load_power
+          - entity: sensor.meter_active_power
+          - entity: sensor.total_dc_power
           - entity: sensor.battery_power
           - entity: sensor.export_power
           - entity: binary_sensor.pv_generating
@@ -21,6 +22,12 @@ views:
           - entity: sensor.phase_c_voltage
           - entity: sensor.phase_c_current
           - entity: sensor.phase_c_power
+          - entity: sensor.meter_phase_a_active_power
+          - entity: sensor.meter_phase_b_active_power
+          - entity: sensor.meter_phase_c_active_power
+          - entity: sensor.backup_phase_a_power
+          - entity: sensor.backup_phase_b_power
+          - entity: sensor.backup_phase_c_power
           - entity: sensor.grid_frequency
         title: Power
       - type: gauge

--- a/PV_Info.yaml
+++ b/PV_Info.yaml
@@ -25,6 +25,7 @@ views:
           - entity: sensor.meter_phase_a_active_power
           - entity: sensor.meter_phase_b_active_power
           - entity: sensor.meter_phase_c_active_power
+          - entity: sensor.total_backup_power
           - entity: sensor.backup_phase_a_power
           - entity: sensor.backup_phase_b_power
           - entity: sensor.backup_phase_c_power

--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -1,7 +1,7 @@
 # Home Assistant Sungrow inverter integration
 # https://github.com/mkaiser/Sungrow-SHx-Inverter-Modbus-Home-Assistant
 # by Martin Kaiser
-# 21th Dezember 2022 
+# 3rd January 2023
 
 modbus:
   - name: SungrowSHx

--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -322,7 +322,7 @@ modbus:
         address: 5722
         input_type: input
         count: 1
-        data_type: uint16
+        data_type: int16
         swap: word
         precision: 0
         unit_of_measurement: W
@@ -336,7 +336,7 @@ modbus:
         address: 5723
         input_type: input
         count: 1
-        data_type: uint16
+        data_type: int16
         swap: word
         precision: 0
         unit_of_measurement: W
@@ -350,7 +350,7 @@ modbus:
         address: 5724
         input_type: input
         count: 1
-        data_type: uint16
+        data_type: int16
         swap: word
         precision: 0
         unit_of_measurement: W

--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -187,7 +187,7 @@ modbus:
 
       - name: Reactive power
         slave: !secret sungrow_modbus_slave
-        address: 5032  
+        address: 5032
         input_type: input
         count: 2
         data_type: int32
@@ -211,6 +211,67 @@ modbus:
         device_class: power_factor
         state_class: measurement
         scale: 0.001
+        scan_interval: 10
+
+#https://www.photovoltaikforum.com/thread/166134-daten-lesen-vom-sungrow-wechselrichtern-modbus/?pageNo=13
+#Meter Active Power: 5601-5602 S32 W (Energiezähler Wirkleistung)
+#Meter Phase A Active Power: 5603-5604 S32 W (Stromzähler Phase A Wirkleistung)
+#Meter Phase B Active Power: 5605-5606 S32 W (Stromzähler Phase B Wirkleistung)
+#Meter Phase C Active Power: 5607-5608 S32 W (Stromzähler Phase C Wirkleistung)
+      - name: Meter active power
+        slave: !secret sungrow_modbus_slave
+        address: 5600
+        input_type: input
+        count: 2
+        data_type: int32
+        swap: word
+        precision: 0
+        unit_of_measurement: W
+        device_class: power
+        state_class: measurement
+        scale: 1
+        scan_interval: 10
+
+      - name: Meter phase A active power
+        slave: !secret sungrow_modbus_slave
+        address: 5602
+        input_type: input
+        count: 2
+        data_type: int32
+        swap: word
+        precision: 0
+        unit_of_measurement: W
+        device_class: power
+        state_class: measurement
+        scale: 1
+        scan_interval: 10
+
+      - name: Meter phase B active power
+        slave: !secret sungrow_modbus_slave
+        address: 5604
+        input_type: input
+        count: 2
+        data_type: int32
+        swap: word
+        precision: 0
+        unit_of_measurement: W
+        device_class: power
+        state_class: measurement
+        scale: 1
+        scan_interval: 10
+
+      - name: Meter phase C active power
+        slave: !secret sungrow_modbus_slave
+        address: 5606
+        input_type: input
+        count: 2
+        data_type: int32
+        swap: word
+        precision: 0
+        unit_of_measurement: W
+        device_class: power
+        state_class: measurement
+        scale: 1
         scan_interval: 10
 
       - name: BDC rated power
@@ -251,6 +312,52 @@ modbus:
         device_class: Current
         scale: 1
         scan_interval: 60 
+
+#https://www.photovoltaikforum.com/thread/166134-daten-lesen-vom-sungrow-wechselrichtern-modbus/?pageNo=13
+#Phase A Backup Power: 5723 S16 W (Backup Leistung Phase A)
+#Phase B Backup Power: 5724 S16 W (Backup Leistung Phase B)
+#Phase C Backup Power: 5725 S16 W (Backup Leistung Phase C)
+      - name: Backup phase A power
+        slave: !secret sungrow_modbus_slave
+        address: 5722
+        input_type: input
+        count: 1
+        data_type: uint16
+        swap: word
+        precision: 0
+        unit_of_measurement: W
+        device_class: power
+        state_class: measurement
+        scale: 1
+        scan_interval: 10
+
+      - name: Backup phase B power
+        slave: !secret sungrow_modbus_slave
+        address: 5723
+        input_type: input
+        count: 1
+        data_type: uint16
+        swap: word
+        precision: 0
+        unit_of_measurement: W
+        device_class: power
+        state_class: measurement
+        scale: 1
+        scan_interval: 10
+
+      - name: Backup phase C power
+        slave: !secret sungrow_modbus_slave
+        address: 5724
+        input_type: input
+        count: 1
+        data_type: uint16
+        swap: word
+        precision: 0
+        unit_of_measurement: W
+        device_class: power
+        state_class: measurement
+        scale: 1
+        scan_interval: 10
 
       - name: System state
         slave: !secret sungrow_modbus_slave
@@ -545,7 +652,6 @@ modbus:
         scale: 0.1
         scan_interval: 10
 
-
       - name: Phase B Current
         slave: !secret sungrow_modbus_slave
         address: 13031  # reg 13032
@@ -560,7 +666,6 @@ modbus:
         scale: 0.1
         scan_interval: 10
 
-
       - name: Phase C Current
         slave: !secret sungrow_modbus_slave
         address: 13032  # reg 13033
@@ -574,7 +679,6 @@ modbus:
         state_class: measurement
         scale: 0.1
         scan_interval: 10
-
 
       - name: Total active power
         slave: !secret sungrow_modbus_slave
@@ -691,7 +795,6 @@ modbus:
         scale: 0.1
         scan_interval: 600
 
-
       # holding registers
       - name: Inverter Start Stop
         slave: !secret sungrow_modbus_slave
@@ -805,7 +908,6 @@ modbus:
         scale: 0.1
         scan_interval: 10
 
-
 #undocumented sensors (reverse engineered by some guys of photovoltaikforum.com and forum.iobroker.net )
       - name: Battery Max Charge Power
         slave: !secret sungrow_modbus_slave
@@ -887,7 +989,6 @@ modbus:
 # h,33032,SOC_lower_limit,"","%",U16,,,0.1
 # h,33046,protection_value_of_battery_average_overvoltage,"","W",U16,,,10
 
-
 binary_sensor:
   - platform: template
     sensors:
@@ -906,8 +1007,6 @@ binary_sensor:
       importing_power:
         friendly_name: "Importing power"
         value_template: "{{ states('sensor.running_state')|int(default=0)|bitwise_and(0x20) > 0 }}"
-
-
 
 # 'virtual' template sensors for better readability
 template:
@@ -941,7 +1040,6 @@ template:
       device_class: power
       state: > 
         {{ (states('sensor.phase_c_voltage') | float * states('sensor.phase_c_current') | float) |int}}
-
 
     - name: "Sungrow Inverter State"
       state: >-
@@ -1048,7 +1146,6 @@ template:
           Unknown - should not see me!
         {% endif %}
 
-
 # getting input for Min and Max SoC
 input_number:
   set_sg_min_soc:
@@ -1093,7 +1190,6 @@ input_number:
     max: 5000
     step: 50
 
-
 input_select:
   set_sg_start_stop_mode:
     name: Inverter mode
@@ -1119,7 +1215,6 @@ input_select:
       - "Forced charge"
       - "Forced discharge"
     icon: mdi:battery-unknown
-
 
 # Automations: Write modbus registers on input changes via GUI
 # note: If you change a value by the sliders, it will take up to 60 seconds until the state variables are updated
@@ -1180,7 +1275,6 @@ automation:
           hub: SungrowSHx
     mode: single
 
-
   - id: "12322468543545" # random number
     alias: "sungrow inverter update battery soc reserve"
     description: "Updates Sungrow battery Soc reserve register"
@@ -1197,8 +1291,6 @@ automation:
           value: "{{ states('input_number.set_sg_batt_soc_reserve') | int *10}}"
           hub: SungrowSHx
     mode: single
-
-
 
   - id: "24321413553543" # random number
     alias: "sungrow inverter update battery forced charge discharge cmd"
@@ -1285,7 +1377,6 @@ automation:
           value: "{{ states('input_number.set_sg_battery_max_charge_power') | int /10}}"
           hub: SungrowSHx
     mode: single
-
 
   - id: "24321203543522" # random number
     alias: "sungrow inverter update battery max discharge power"

--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -317,6 +317,20 @@ modbus:
 #Phase A Backup Power: 5723 S16 W (Backup Leistung Phase A)
 #Phase B Backup Power: 5724 S16 W (Backup Leistung Phase B)
 #Phase C Backup Power: 5725 S16 W (Backup Leistung Phase C)
+      - name: Total backup power
+        slave: !secret sungrow_modbus_slave
+        address: 5725
+        input_type: input
+        count: 1
+        data_type: int16
+        swap: word
+        precision: 0
+        unit_of_measurement: W
+        device_class: power
+        state_class: measurement
+        scale: 1
+        scan_interval: 10
+
       - name: Backup phase A power
         slave: !secret sungrow_modbus_slave
         address: 5722


### PR DESCRIPTION
Dear mkaiser,
I added some values for the backup loads and some power reading from the smart meter. Source for the undocumented addresses is: https://www.photovoltaikforum.com/thread/166134-daten-lesen-vom-sungrow-wechselrichtern-modbus/?pageNo=13

It is tested OK with my SH10RT-V112

Best regards,
Dirk
