### PR TITLE
Fixed some issues and added some sensors

### DIFF
--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -9,10 +9,10 @@ modbus:
     host: !secret sungrow_modbus_host_ip
     port: !secret sungrow_modbus_port
     retry_on_empty: true
-    # retries: 10
-    # close_comm_on_error: true
+    retries: 10
+    close_comm_on_error: true
     delay: 5
-    #timeout: 5
+    # timeout: 5
     sensors:
       - name: Sungrow device type code
         unique_id: sg_dev_code
@@ -1358,18 +1358,7 @@ template:
           {% else %}
             Unknown - should not see me!
           {% endif %}
-          
-      - name: "Daily Compensation"
-        unit_of_measurement: €
-        device_class: energy
-        state: >
-          {{ states('sensor.daily_exported_energy') | float * states('input_number.set_sg_feedin_compensation_per_kwh') | float}}
-
-      - name: "Daily energy cost"
-        unit_of_measurement: €
-        device_class: energy
-        state: >
-          {{ states('sensor.daily_imported_energy') | float * states('input_number.set_sg_energy_cost_per_kwh') | float}}
+         
       
       - name: "Signed Battery Power" # positive if charging and negative if discharging
         unique_id: sg_signed_battery_power
@@ -1453,17 +1442,6 @@ input_number:
     max: 50
     step: 1
   
-  set_sg_energy_cost_per_kwh:
-    name: Set energy cost per kWh
-    min: 0
-    max: 1
-    step: 0.001
-  
-  set_sg_feedin_compensation_per_kwh:
-    name: Set feedin compensation per kWh
-    min: 0
-    max: 1
-    step: 0.001
 
   set_sg_max_soc:
     name: Set max SoC

--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -483,6 +483,36 @@ modbus:
         scale: 1
         scan_interval: 600
         
+      - name: Monthly direct energy consumption
+        unique_id: sg_monthly_direct_energy_consumption
+        slave: !secret sungrow_modbus_slave
+        address: 6418
+        input_type: input
+        count: 1
+        data_type: uint16
+        swap: word
+        precision: 1
+        unit_of_measurement: kWh
+        device_class: energy
+        state_class: total_increasing
+        scale: 1
+        scan_interval: 600
+        
+      - name: Yearly direct energy consumption
+        unique_id: sg_yearly_direct_energy_consumption
+        slave: !secret sungrow_modbus_slave
+        address: 6430
+        input_type: input
+        count: 1
+        data_type: uint16
+        swap: word
+        precision: 1
+        unit_of_measurement: kWh
+        device_class: energy
+        state_class: total_increasing
+        scale: 1
+        scan_interval: 600
+        
       - name: Yearly export energy from PV
         unique_id: sg_yearly_export_energy_from_pv
         slave: !secret sungrow_modbus_slave

--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -434,8 +434,68 @@ modbus:
         precision: 1
         unit_of_measurement: kWh
         device_class: energy
-        state_class: measurement
+        state_class: total_increasing
         scale: 0.1
+        scan_interval: 600
+       
+      - name: Monthly PV energy yields
+        unique_id: sg_monthly_pv_energy_yields
+        slave: !secret sungrow_modbus_slave
+        address: 6228
+        input_type: input
+        count: 1
+        data_type: uint16
+        swap: word
+        precision: 1
+        unit_of_measurement: kWh
+        device_class: energy
+        state_class: total_increasing
+        scale: 1
+        scan_interval: 600
+        
+      - name: Yearly PV energy yields
+        unique_id: sg_yearly_pv_energy_yields
+        slave: !secret sungrow_modbus_slave
+        address: 6250
+        input_type: input
+        count: 1
+        data_type: uint32
+        swap: word
+        precision: 1
+        unit_of_measurement: kWh
+        device_class: energy
+        state_class: total_increasing
+        scale: 1
+        scan_interval: 600
+        
+      - name: Monthly export energy from PV
+        unique_id: sg_monthly_export_energy_from_pv
+        slave: !secret sungrow_modbus_slave
+        address: 6596
+        input_type: input
+        count: 1
+        data_type: uint16
+        swap: word
+        precision: 1
+        unit_of_measurement: kWh
+        device_class: energy
+        state_class: total_increasing
+        scale: 1
+        scan_interval: 600
+        
+      - name: Yearly export energy from PV
+        unique_id: sg_yearly_export_energy_from_pv
+        slave: !secret sungrow_modbus_slave
+        address: 6608
+        input_type: input
+        count: 1
+        data_type: uint32
+        swap: word
+        precision: 1
+        unit_of_measurement: kWh
+        device_class: energy
+        state_class: total_increasing
+        scale: 1
         scan_interval: 600
 
       - name: Total PV generation
@@ -449,7 +509,7 @@ modbus:
         precision: 1
         unit_of_measurement: kWh
         device_class: energy
-        state_class: total_increasing
+        state_class: total
         scale: 0.1
         scan_interval: 600
 
@@ -464,7 +524,7 @@ modbus:
         precision: 1
         unit_of_measurement: kWh
         device_class: energy
-        state_class: measurement
+        state_class: total_increasing
         scale: 0.1
         scan_interval: 600
 
@@ -479,7 +539,7 @@ modbus:
         precision: 1
         unit_of_measurement: kWh
         device_class: energy
-        state_class: total_increasing
+        state_class: total
         scale: 0.1
         scan_interval: 600
 
@@ -1268,6 +1328,37 @@ template:
           {% else %}
             Unknown - should not see me!
           {% endif %}
+          
+      - name: "Daily Compensation"
+        unit_of_measurement: €
+        device_class: energy
+        state: >
+          {{ states('sensor.daily_exported_energy') | float * states('input_number.set_sg_feedin_compensation_per_kwh') | float}}
+
+      - name: "Daily energy cost"
+        unit_of_measurement: €
+        device_class: energy
+        state: >
+          {{ states('sensor.daily_imported_energy') | float * states('input_number.set_sg_energy_cost_per_kwh') | float}}
+      
+      - name: "Signed Battery Power" # positive if charging and negative if discharging
+        unique_id: sg_signed_battery_power
+        unit_of_measurement: W
+        device_class: power
+        state: >
+          {% if is_state('binary_sensor.battery_charging', 'unavailable') or is_state('binary_sensor.battery_discharging', 'unavailable') or is_state('sensor.battery_power_raw', 'unavailable') %}
+            unavailable
+          {% elif is_state('binary_sensor.battery_charging', 'on') %}
+            {{ (states('sensor.battery_power_raw') | float * 1 | float) |int }} 
+          {% elif is_state('binary_sensor.battery_discharging', 'on') %} 
+            {{ (states('sensor.battery_power_raw') | float * -1 | float) |int }} 
+          {% else %} 
+            {{ (states('sensor.battery_power_raw') | float * 1 | float) |int }} 
+          {% endif %}
+            {{ (states('sensor.battery_power_raw') | float * 1 | float) |int }} 
+          {% endif %}
+            {{ (states('sensor.battery_power_raw') | float * 1 | float) |int }} 
+          {% endif %}
 
       - name: "Battery charging power" # positive if charging else zero
         unique_id: sg_battery_charging_power
@@ -1331,6 +1422,18 @@ input_number:
     min: 5
     max: 50
     step: 1
+  
+  set_sg_energy_cost_per_kwh:
+    name: Set energy cost per kWh
+    min: 0
+    max: 1
+    step: 0.001
+  
+  set_sg_feedin_compensation_per_kwh:
+    name: Set feedin compensation per kWh
+    min: 0
+    max: 1
+    step: 0.001
 
   set_sg_max_soc:
     name: Set max SoC


### PR DESCRIPTION
I wanted to set up the Energy Dashboard and I couldn't add some entities, because they lacked last_reset. I fixed all of the entities that didn't work and added the sensors:
Monthly direct energy consumption
Yearly direct energy consumption
Monthly PV energy yields
Yearly PV energy yields
Monthly exported energy from PV
Yearly exported energy from PV

I added unique ids to the sensors I added.