### PR TITLE
Add Sun to Glance in Overview Dashboard

### DIFF
--- a/dashboard.yaml
+++ b/dashboard.yaml
@@ -34,6 +34,7 @@ views:
         show_state: false
         type: glance
         entities:
+          - entity: sun.sun
           - entity: binary_sensor.pv_generating
           - entity: binary_sensor.battery_charging
           - entity: binary_sensor.battery_discharging


### PR DESCRIPTION
With the sun in the glance panel, you can see directly whether the PV system should be producing or not. and it now looks nice with 2*3 symbols
