### PR TITLE
sg_battery_capacity uses wrong scale. #72

### DIFF
--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -1122,7 +1122,7 @@ modbus:
         swap: word
         unit_of_measurement: kWh
         device_class: energy
-        scale: 10
+        scale: 0.01
         scan_interval: 600
 
       - name: Battery charging start power


### PR DESCRIPTION
Found the source for the definition. [photovoltaikforum.de](https://www.photovoltaikforum.com/thread/166134-daten-lesen-vom-sungrow-wechselrichtern-modbus/?postID=2837513&highlight=33049#post2837513). Scale should be 0.01 