### PR TITLE
Fix sg_battery_level_nom calculation

### DIFF
--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -2188,7 +2188,7 @@ template:
           {% set soc_max = states('sensor.max_soc') | float %}
           {% set soc_cur = states('sensor.battery_level') | float %}
           {{
-            (soc_min) + (soc_max - soc_min) * (soc_cur / 100) | round(1) 
+            ((soc_min) + ((soc_max - soc_min) * (soc_cur / 100))) | round(1) 
           }}
 
       - name: "Battery charge (nominal)"


### PR DESCRIPTION
In the current implementation some brackets are missing.

Current implementation example:
soc_min = 5%
soc_max = 95%
soc_cur = 75%
level_nom = 77% (wrong due to missing brackets)

Fixed implementation:
soc_min = 5%
soc_max = 95%
soc_cur = 75%
level_nom = 72,5%