### PR TITLE
Removing empty lines

### DIFF
--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -1554,21 +1554,6 @@ modbus:
         scale: 0.1
         scan_interval: 600
 
-											  
-												 
-										   
-								  
-						 
-				
-						 
-				  
-					
-							  
-						   
-								
-				
-						 
-
       #####################
       # holding registers
       #####################
@@ -1621,31 +1606,6 @@ modbus:
         device_class: power
         state_class: measurement
         scan_interval: 10
-
-						
-							
-											 
-								
-							 
-				  
-						   
-					
-					  
-						   
-
-						 
-									   
-								   
-											 
-							   
-							 
-				  
-							
-						   
-					
-					  
-								   
-				  
 
       - name: Max SoC
         unique_id: sg_max_soc
@@ -1760,17 +1720,6 @@ modbus:
         device_class: energy
         scale: 0.01
         scan_interval: 600
-
-										 
-												 
-										   
-								  
-						   
-				
-						 
-				  
-					
-						 
 
       - name: Battery charging start power
         unique_id: sg_battery_charging_start_power


### PR DESCRIPTION
Removing empty lines that causes Home Assistant yaml config checker to complain about