### PR TITLE
Fix battery charging / discharging state 

### DIFF
--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -1762,7 +1762,11 @@ template:
         state: >-
           {% if states('sensor.running_state')|is_number %}
             {# use available sensor running_state #}
-            {{ states('sensor.running_state')|int(default=0)|bitwise_and(0x2) > 0 }}
+            {% if states('sensor.running_state')|int(default=0)|bitwise_and(0x2) > 0 %}
+              on
+            {% else %}
+              off
+            {% endif %}
           {% else %}
             {# workaround for SH*RS inverters without working running_state #}
             {% if (states('sensor.ems_mode_selection') ) == "Forced mode" %}
@@ -1806,7 +1810,11 @@ template:
         state: >-
           {% if states('sensor.running_state')|is_number %}
             {# use available sensor running_state #}
-            {{ states('sensor.running_state')|int(default=0)|bitwise_and(0x4) > 0 }}
+            {% if states('sensor.running_state')|int(default=0)|bitwise_and(0x4) > 0 %}
+              on
+            {% else %}
+              off
+            {% endif %}
           {% else %}
             {# workaround for SH*RS inverters without working running_state #}
             {% if (states('sensor.ems_mode_selection') ) == "Forced mode" %}


### PR DESCRIPTION
copied from #139

Hi I had a problem where my sr10rt didn't know if it was charging or discharging. Anyway long story short
I changed this code line from https://github.com/mkaiser/Sungrow-SHx-Inverter-Modbus-Home-Assistant/blob/main/modbus_sungrow.yaml#L1765C1-L1765C85

{{ states('sensor.running_state')|int(default=0)|bitwise_and(0x2) > 0 }}

to

{% if states('sensor.running_state')|int(default=0)|bitwise_and(0x2) > 0 %}
on
{% else %}
off
{% endif %}

and did this to the discharge logic on this line https://github.com/mkaiser/Sungrow-SHx-Inverter-Modbus-Home-Assistant/blob/main/modbus_sungrow.yaml#L1809

{% if states('sensor.running_state')|int(default=0)|bitwise_and(0x4) > 0 %}
on
{% else %}
off
{% endif %}