### PR TITLE
Fix battery_charge_nominal and sensor.battery_charge

### DIFF
--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -2198,7 +2198,7 @@ template:
       - name: "Battery charge (nominal)"
         unique_id: sg_battery_charge_nom
         unit_of_measurement: kWh
-        device_class: battery
+        device_class: energy
         state_class: measurement
         availability: >-
           {{ 
@@ -2214,7 +2214,7 @@ template:
       - name: "Battery charge"
         unique_id: sg_battery_charge
         unit_of_measurement: kWh
-        device_class: battery
+        device_class: energy
         state_class: measurement
         availability: >-
           {{ 

--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -1518,7 +1518,7 @@ modbus:
         input_type: holding
         data_type: uint16
         unit_of_measurement: kWh
-        device_class: energy
+        device_class: energy_storage
         scale: 0.01
         scan_interval: 600
 
@@ -2198,7 +2198,7 @@ template:
       - name: "Battery charge (nominal)"
         unique_id: sg_battery_charge_nom
         unit_of_measurement: kWh
-        device_class: energy
+        device_class: energy_storage
         state_class: measurement
         availability: >-
           {{ 
@@ -2214,7 +2214,7 @@ template:
       - name: "Battery charge"
         unique_id: sg_battery_charge
         unit_of_measurement: kWh
-        device_class: energy
+        device_class: energy_storage
         state_class: measurement
         availability: >-
           {{ 

--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -1,7 +1,7 @@
 # Home Assistant Sungrow inverter integration
 # https://github.com/mkaiser/Sungrow-SHx-Inverter-Modbus-Home-Assistant
 # by Martin Kaiser
-# last update: 2023-10-28
+# last update: 2023-11-04
 #
 # Note: This YAML file will only work with Home Assistant >= 2023.10
 


### PR DESCRIPTION
Reported by:
https://github.com/mkaiser/Sungrow-SHx-Inverter-Modbus-Home-Assistant/issues/200 

According to https://developers.home-assistant.io/docs/core/entity/sensor/ 

device_class: battery has only % as supported unit of measurement. Here we need device_class: energy 
Or maybe even device_class: energy_storage ???