### PR TITLE
Updated inverter state sensor to support a value of 0x0000 for Running

### DIFF
--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -1902,7 +1902,7 @@ template:
             Initial Standby
           {% elif ((states('sensor.system_state') | int(default=0)) == 0x0020) %}
             Startup
-          {% elif ((states('sensor.system_state') | int(default=0)) == 0x0040) %}
+          {% elif ((states('sensor.system_state') | int(default=0)) in [0x0000,0x0040]) %}
             Running
           {% elif ((states('sensor.system_state') | int(default=0)) == 0x0100) %}
             Fault

--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -1,7 +1,7 @@
 # Home Assistant Sungrow inverter integration
 # https://github.com/mkaiser/Sungrow-SHx-Inverter-Modbus-Home-Assistant
 # by Martin Kaiser
-# last update: 2023-11-04 (2)
+# last update: 2023-11-12
 #
 # Note: This YAML file will only work with Home Assistant >= 2023.10
 

--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -1951,6 +1951,10 @@ template:
             SH5.0RS
           {% elif ((states('sensor.sungrow_device_type_code') | int(default=0)) == 0x0D10) %}
             SH6.0RS
+          {% elif ((states('sensor.sungrow_device_type_code') | int(default=0)) == 0x0D1A) %}
+            SH8.0RS
+          {% elif ((states('sensor.sungrow_device_type_code') | int(default=0)) == 0x0D1B) %}
+            SH10RS
           {% elif ((states('sensor.sungrow_device_type_code') | int(default=0)) == 0x0E00) %}
             SH5.0RT
           {% elif ((states('sensor.sungrow_device_type_code') | int(default=0)) == 0x0E01) %}


### PR DESCRIPTION
Latest Sungrow Modbus doc indicates that either 0x0000 or 0x0040 are valid values for the Running state. SH10RS returns 0x0000
Relates to #184 