### PR TITLE
Battery capacity to display decimal precision

### DIFF
--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -1,7 +1,7 @@
 # Home Assistant Sungrow inverter integration
 # https://github.com/mkaiser/Sungrow-SHx-Inverter-Modbus-Home-Assistant
 # by Martin Kaiser
-# last update: 2023-12-31
+# last update: 2024-03-26
 #
 # Note: This YAML file will only work with Home Assistant >= 2023.10
 

--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -1516,6 +1516,7 @@ modbus:
         address: 33048 # reg 33049
         input_type: holding
         data_type: uint16
+        precision: 1
         unit_of_measurement: kWh
         device_class: energy_storage
         scale: 0.01


### PR DESCRIPTION
The battery capacity in HomeAssistant is displayed without decimal precision.
E.g. in my case with an SBR096 with 9.6kWh it is displayed as 10 kWh.
Adding the precision parameter in the yaml of sensor sg_battery_capacity will change the displaying and also correct calculation of dependent template sensors.