### PR TITLE
Update modbus_sungrow.yaml

### DIFF
--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -1,7 +1,7 @@
 # Home Assistant Sungrow inverter integration
 # https://github.com/mkaiser/Sungrow-SHx-Inverter-Modbus-Home-Assistant
 # by Martin Kaiser
-# last update: 2024-08-19
+# last update: 2024-09-16 (2)
 #
 # Note: This YAML file will only work with Home Assistant >= 2023.10
 

--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -9,7 +9,9 @@ modbus:
   - name: SungrowSHx
     type: tcp
     host: !secret sungrow_modbus_host_ip
-    port: !secret sungrow_modbus_port
+    port: !secret sungrow_modbus_port  
+    delay: 5
+    timeout: 10
     sensors:
       - name: Sungrow device type code
         unique_id: sg_dev_code


### PR DESCRIPTION
Added delay and timeout to prevent issues with inverter not responding randomly.

my sungrow SH10RT wouldn't respond at all past home assistant 2024.4.4 without it.