### PR TITLE
Treat running_state==0 the same as 'unavailable'

### DIFF
--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -1669,7 +1669,7 @@ template:
           and not is_state('sensor.total_dc_power', 'unavailable') 
           }}
         state: >-
-          {% if states('sensor.running_state')|is_number %}
+          {% if states('sensor.running_state')|is_number and states('sensor.running_state')|float > 0 %}
             {# use available sensor running_state #}
             {{ states('sensor.running_state')|int |bitwise_and(0x1) }}
           {% else %} 
@@ -1708,7 +1708,7 @@ template:
             )
           }}
         state: >-
-          {% if states('sensor.running_state')|is_number %}
+          {% if states('sensor.running_state')|is_number and states('sensor.running_state')|float > 0 %}
             {# use available sensor running_state #}
             {% if states('sensor.running_state')|int|bitwise_and(0x2) > 0 %}
               on
@@ -1770,7 +1770,7 @@ template:
             )
           }}
         state: >-
-          {% if states('sensor.running_state')|is_number %}
+          {% if states('sensor.running_state')|is_number and states('sensor.running_state')|float > 0 %}
             {# use available sensor running_state #}
             {% if states('sensor.running_state')|int|bitwise_and(0x4) > 0 %}
               on
@@ -1826,7 +1826,7 @@ template:
           and not is_state('sensor.export_power_raw', 'unavailable') 
           }}
         state: >-
-          {% if states('sensor.running_state')|is_number %}
+          {% if states('sensor.running_state')|is_number and states('sensor.running_state')|float > 0 %}
             {# use available sensor running_state #}
             {{ states('sensor.running_state')|int|bitwise_and(0x10) > 0 }}
           {% else %} 
@@ -1859,7 +1859,7 @@ template:
           and not is_state('sensor.running_state', 'unavailable')
           }}
         state: >-
-          {% if states('sensor.running_state')|is_number %}
+          {% if states('sensor.running_state')|is_number and states('sensor.running_state')|float > 0 %}
             {# use available sensor running_state #}
             {{ states('sensor.running_state')|int|bitwise_and(0x20) > 0 }}
           {% else %} 

--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -1,7 +1,7 @@
 # Home Assistant Sungrow inverter integration
 # https://github.com/mkaiser/Sungrow-SHx-Inverter-Modbus-Home-Assistant
 # by Martin Kaiser
-# last update: 2024-08-19
+# last update: 2024-09-16(3)
 #
 # Note: This YAML file will only work with Home Assistant >= 2023.10
 


### PR DESCRIPTION
This works around an issue where running_state is stuck at 0 on some inverter & firmware versions, such as SH15T.

Fixes #338