### PR TITLE
fixed syntax error in entity definition "Sungrow inverter state"

### DIFF
--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -2057,9 +2057,9 @@ template:
             Restarting
           {% elif ((states('sensor.system_state') |int) == 0x4000) %}
             External EMS mode
-          {% elif ((states('sensor.system_state') |int) == in [0x55000,0x0100]) %}
+          {% elif ((states('sensor.system_state') |int) in [0x55000,0x0100]) %}
             Fault
-          {% elif ((states('sensor.system_state') |int) == in [0x8000,0x0001]) %}
+          {% elif ((states('sensor.system_state') |int) in [0x8000,0x0001]) %}
             Stop
           {% elif ((states('sensor.system_state') |int) == 0x8100) %}
             De-rating Running

--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -1,7 +1,7 @@
 # Home Assistant Sungrow inverter integration
 # https://github.com/mkaiser/Sungrow-SHx-Inverter-Modbus-Home-Assistant
 # by Martin Kaiser
-# last update: 2024-09-30
+# last update: 2024-09-30 (2)
 #
 # Note: This YAML file will only work with Home Assistant >= 2023.10
 


### PR DESCRIPTION
#356 