### PR TITLE
register 5725 total backup power should have int32

### DIFF
--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -1,7 +1,7 @@
 # Home Assistant Sungrow inverter integration
 # https://github.com/mkaiser/Sungrow-SHx-Inverter-Modbus-Home-Assistant
 # by Martin Kaiser
-# last update: 2024-09-21
+# last update: 2024-10-12
 #
 # Note: This YAML file will only work with Home Assistant >= 2023.10
 

--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -334,7 +334,7 @@ modbus:
         unique_id: sg_total_backup_power
         address: 5725 # reg 5726
         input_type: input
-        data_type: int16
+        data_type: int32
         precision: 0
         unit_of_measurement: W
         device_class: power


### PR DESCRIPTION
this register line other backup power registers should be changed to 32 integer as per sungrow manual but should also remain as signed power - as that part is a typo from sungrow.