### PR TITLE
Use register 5242 for high precision grid frequency

### DIFF
--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -1,7 +1,7 @@
 # Home Assistant Sungrow inverter integration
 # https://github.com/mkaiser/Sungrow-SHx-Inverter-Modbus-Home-Assistant
 # by Martin Kaiser
-# last update: 2024-10-12 (2)
+# last update: 2024-10-13 (2)
 #
 # Note: This YAML file will only work with Home Assistant >= 2023.10
 
@@ -185,20 +185,7 @@ modbus:
         state_class: measurement
         scale: 0.1
         scan_interval: 10
-
-      - name: Grid frequency
-        unique_id: sg_grid_frequency
-        device_address: !secret sungrow_modbus_slave
-        address: 5241 # reg 5242
-        input_type: input
-        data_type: uint16
-        precision: 2
-        unit_of_measurement: "Hz"
-        device_class: frequency
-        state_class: measurement
-        scale: 0.01
-        scan_interval: 10
-
+        
       - name: Reactive power
         unique_id: sg_reactive_power
         device_address: !secret sungrow_modbus_slave
@@ -225,6 +212,19 @@ modbus:
         state_class: measurement
         scale: 0.001
         scan_interval: 10
+
+      - name: Grid frequency
+        unique_id: sg_grid_frequency
+        device_address: !secret sungrow_modbus_slave
+        address: 5241 # reg 5242
+        input_type: input
+        data_type: uint16
+        precision: 2
+        unit_of_measurement: "Hz"
+        device_class: frequency
+        state_class: measurement
+        scale: 0.01
+        scan_interval: 10        
 
       #https://www.photovoltaikforum.com/thread/166134-daten-lesen-vom-sungrow-wechselrichtern-modbus/?pageNo=13
       #Meter Active Power: 5601-5602 S32 W (Energiezähler Wirkleistung)

--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -189,14 +189,14 @@ modbus:
       - name: Grid frequency
         unique_id: sg_grid_frequency
         device_address: !secret sungrow_modbus_slave
-        address: 5035 # reg 5036
+        address: 5241 # reg 5242
         input_type: input
         data_type: uint16
         precision: 2
         unit_of_measurement: "Hz"
         device_class: frequency
         state_class: measurement
-        scale: 0.1
+        scale: 0.01
         scan_interval: 10
 
       - name: Reactive power


### PR DESCRIPTION
Sensor was already set to precision 2 even though scale was 0.1. This way, the actual grid frequency fluctuation is visible.