### PR TITLE
Use higher precision for meter current values

### DIFF
--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -1,7 +1,7 @@
 # Home Assistant Sungrow inverter integration
 # https://github.com/mkaiser/Sungrow-SHx-Inverter-Modbus-Home-Assistant
 # by Martin Kaiser
-# last update: 2024-10-12 (2)
+# last update: 2024-10-14
 #
 # Note: This YAML file will only work with Home Assistant >= 2023.10
 

--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -439,7 +439,7 @@ modbus:
         address: 5743 # reg 5744
         input_type: input
         data_type: uint16
-        precision: 0
+        precision: 2
         unit_of_measurement: A
         device_class: current
         state_class: measurement
@@ -452,7 +452,7 @@ modbus:
         address: 5744 # reg 5745
         input_type: input
         data_type: uint16
-        precision: 0
+        precision: 2
         unit_of_measurement: A
         device_class: current
         state_class: measurement
@@ -465,7 +465,7 @@ modbus:
         address: 5745 # reg 5746
         input_type: input
         data_type: uint16
-        precision: 0
+        precision: 2
         unit_of_measurement: A
         device_class: current
         state_class: measurement

--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -287,6 +287,85 @@ modbus:
         scale: 1
         scan_interval: 10
 
+      # https://www.photovoltaikforum.com/thread/166134-daten-lesen-vom-sungrow-wechselrichtern-modbus/?postID=3324464#post3324464
+      - name: Meter phase A voltage
+        unique_id: sg_meter_phase_a_voltage
+        device_address: !secret sungrow_modbus_slave
+        address: 5740 # reg 5741
+        input_type: input
+        data_type: int16
+        precision: 1
+        unit_of_measurement: V
+        device_class: voltage
+        state_class: measurement
+        scale: 0.1
+        scan_interval: 10
+
+      - name: Meter phase B voltage
+        unique_id: sg_meter_phase_b_voltage
+        device_address: !secret sungrow_modbus_slave
+        address: 5741 # reg 5742
+        input_type: input
+        data_type: int16
+        precision: 1
+        unit_of_measurement: V
+        device_class: voltage
+        state_class: measurement
+        scale: 0.1
+        scan_interval: 10
+
+      - name: Meter phase C voltage
+        unique_id: sg_meter_phase_c_voltage
+        device_address: !secret sungrow_modbus_slave
+        address: 5742 # reg 5743
+        input_type: input
+        data_type: int16
+        precision: 1
+        unit_of_measurement: V
+        device_class: voltage
+        state_class: measurement
+        scale: 0.1
+        scan_interval: 10
+
+      - name: Meter phase A current
+        unique_id: sg_meter_phase_a_current
+        device_address: !secret sungrow_modbus_slave
+        address: 5743 # reg 5744
+        input_type: input
+        data_type: uint16
+        precision: 2
+        unit_of_measurement: A
+        device_class: current
+        state_class: measurement
+        scale: 0.01
+        scan_interval: 10
+
+      - name: Meter phase B current
+        unique_id: sg_meter_phase_b_current
+        device_address: !secret sungrow_modbus_slave
+        address: 5744 # reg 5745
+        input_type: input
+        data_type: uint16
+        precision: 2
+        unit_of_measurement: A
+        device_class: current
+        state_class: measurement
+        scale: 0.01
+        scan_interval: 10
+
+      - name: Meter phase C current
+        unique_id: sg_meter_phase_c_current
+        device_address: !secret sungrow_modbus_slave
+        address: 5745 # reg 5746
+        input_type: input
+        data_type: uint16
+        precision: 2
+        unit_of_measurement: A
+        device_class: current
+        state_class: measurement
+        scale: 0.01
+        scan_interval: 10
+
       - name: BDC rated power
         unique_id: sg_bdc_rated_power
         device_address: !secret sungrow_modbus_slave
@@ -391,85 +470,6 @@ modbus:
         device_class: power
         state_class: measurement
         scale: 1
-        scan_interval: 10
-
-      # https://www.photovoltaikforum.com/thread/166134-daten-lesen-vom-sungrow-wechselrichtern-modbus/?postID=3324464#post3324464
-      - name: Meter phase A voltage
-        unique_id: sg_meter_phase_a_voltage
-        device_address: !secret sungrow_modbus_slave
-        address: 5740 # reg 5741
-        input_type: input
-        data_type: int16
-        precision: 1
-        unit_of_measurement: V
-        device_class: voltage
-        state_class: measurement
-        scale: 0.1
-        scan_interval: 10
-
-      - name: Meter phase B voltage
-        unique_id: sg_meter_phase_b_voltage
-        device_address: !secret sungrow_modbus_slave
-        address: 5741 # reg 5742
-        input_type: input
-        data_type: int16
-        precision: 1
-        unit_of_measurement: V
-        device_class: voltage
-        state_class: measurement
-        scale: 0.1
-        scan_interval: 10
-
-      - name: Meter phase C voltage
-        unique_id: sg_meter_phase_c_voltage
-        device_address: !secret sungrow_modbus_slave
-        address: 5742 # reg 5743
-        input_type: input
-        data_type: int16
-        precision: 1
-        unit_of_measurement: V
-        device_class: voltage
-        state_class: measurement
-        scale: 0.1
-        scan_interval: 10
-
-      - name: Meter phase A current
-        unique_id: sg_meter_phase_a_current
-        device_address: !secret sungrow_modbus_slave
-        address: 5743 # reg 5744
-        input_type: input
-        data_type: uint16
-        precision: 2
-        unit_of_measurement: A
-        device_class: current
-        state_class: measurement
-        scale: 0.01
-        scan_interval: 10
-
-      - name: Meter phase B current
-        unique_id: sg_meter_phase_b_current
-        device_address: !secret sungrow_modbus_slave
-        address: 5744 # reg 5745
-        input_type: input
-        data_type: uint16
-        precision: 2
-        unit_of_measurement: A
-        device_class: current
-        state_class: measurement
-        scale: 0.01
-        scan_interval: 10
-
-      - name: Meter phase C current
-        unique_id: sg_meter_phase_c_current
-        device_address: !secret sungrow_modbus_slave
-        address: 5745 # reg 5746
-        input_type: input
-        data_type: uint16
-        precision: 2
-        unit_of_measurement: A
-        device_class: current
-        state_class: measurement
-        scale: 0.01
         scan_interval: 10
 
       # Start monthly PV generation

--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -287,85 +287,6 @@ modbus:
         scale: 1
         scan_interval: 10
 
-      # https://www.photovoltaikforum.com/thread/166134-daten-lesen-vom-sungrow-wechselrichtern-modbus/?postID=3324464#post3324464
-      - name: Meter phase A voltage
-        unique_id: sg_meter_phase_a_voltage
-        device_address: !secret sungrow_modbus_slave
-        address: 5740 # reg 5741
-        input_type: input
-        data_type: int16
-        precision: 1
-        unit_of_measurement: V
-        device_class: voltage
-        state_class: measurement
-        scale: 0.1
-        scan_interval: 10
-
-      - name: Meter phase B voltage
-        unique_id: sg_meter_phase_b_voltage
-        device_address: !secret sungrow_modbus_slave
-        address: 5741 # reg 5742
-        input_type: input
-        data_type: int16
-        precision: 1
-        unit_of_measurement: V
-        device_class: voltage
-        state_class: measurement
-        scale: 0.1
-        scan_interval: 10
-
-      - name: Meter phase C voltage
-        unique_id: sg_meter_phase_c_voltage
-        device_address: !secret sungrow_modbus_slave
-        address: 5742 # reg 5743
-        input_type: input
-        data_type: int16
-        precision: 1
-        unit_of_measurement: V
-        device_class: voltage
-        state_class: measurement
-        scale: 0.1
-        scan_interval: 10
-
-      - name: Meter phase A current
-        unique_id: sg_meter_phase_a_current
-        device_address: !secret sungrow_modbus_slave
-        address: 5743 # reg 5744
-        input_type: input
-        data_type: uint16
-        precision: 2
-        unit_of_measurement: A
-        device_class: current
-        state_class: measurement
-        scale: 0.01
-        scan_interval: 10
-
-      - name: Meter phase B current
-        unique_id: sg_meter_phase_b_current
-        device_address: !secret sungrow_modbus_slave
-        address: 5744 # reg 5745
-        input_type: input
-        data_type: uint16
-        precision: 2
-        unit_of_measurement: A
-        device_class: current
-        state_class: measurement
-        scale: 0.01
-        scan_interval: 10
-
-      - name: Meter phase C current
-        unique_id: sg_meter_phase_c_current
-        device_address: !secret sungrow_modbus_slave
-        address: 5745 # reg 5746
-        input_type: input
-        data_type: uint16
-        precision: 2
-        unit_of_measurement: A
-        device_class: current
-        state_class: measurement
-        scale: 0.01
-        scan_interval: 10
-
       - name: BDC rated power
         unique_id: sg_bdc_rated_power
         device_address: !secret sungrow_modbus_slave
@@ -470,6 +391,85 @@ modbus:
         device_class: power
         state_class: measurement
         scale: 1
+        scan_interval: 10
+
+      # https://www.photovoltaikforum.com/thread/166134-daten-lesen-vom-sungrow-wechselrichtern-modbus/?postID=3324464#post3324464
+      - name: Meter phase A voltage
+        unique_id: sg_meter_phase_a_voltage
+        device_address: !secret sungrow_modbus_slave
+        address: 5740 # reg 5741
+        input_type: input
+        data_type: int16
+        precision: 1
+        unit_of_measurement: V
+        device_class: voltage
+        state_class: measurement
+        scale: 0.1
+        scan_interval: 10
+
+      - name: Meter phase B voltage
+        unique_id: sg_meter_phase_b_voltage
+        device_address: !secret sungrow_modbus_slave
+        address: 5741 # reg 5742
+        input_type: input
+        data_type: int16
+        precision: 1
+        unit_of_measurement: V
+        device_class: voltage
+        state_class: measurement
+        scale: 0.1
+        scan_interval: 10
+
+      - name: Meter phase C voltage
+        unique_id: sg_meter_phase_c_voltage
+        device_address: !secret sungrow_modbus_slave
+        address: 5742 # reg 5743
+        input_type: input
+        data_type: int16
+        precision: 1
+        unit_of_measurement: V
+        device_class: voltage
+        state_class: measurement
+        scale: 0.1
+        scan_interval: 10
+
+      - name: Meter phase A current
+        unique_id: sg_meter_phase_a_current
+        device_address: !secret sungrow_modbus_slave
+        address: 5743 # reg 5744
+        input_type: input
+        data_type: uint16
+        precision: 2
+        unit_of_measurement: A
+        device_class: current
+        state_class: measurement
+        scale: 0.01
+        scan_interval: 10
+
+      - name: Meter phase B current
+        unique_id: sg_meter_phase_b_current
+        device_address: !secret sungrow_modbus_slave
+        address: 5744 # reg 5745
+        input_type: input
+        data_type: uint16
+        precision: 2
+        unit_of_measurement: A
+        device_class: current
+        state_class: measurement
+        scale: 0.01
+        scan_interval: 10
+
+      - name: Meter phase C current
+        unique_id: sg_meter_phase_c_current
+        device_address: !secret sungrow_modbus_slave
+        address: 5745 # reg 5746
+        input_type: input
+        data_type: uint16
+        precision: 2
+        unit_of_measurement: A
+        device_class: current
+        state_class: measurement
+        scale: 0.01
         scan_interval: 10
 
       # Start monthly PV generation


### PR DESCRIPTION
The registers for the power meter phase current values report at 0.01 A precision (wish the other current values did that 😔).

Also, I moved the current & voltage sensors to be near the older power sensors.