### PR TITLE
Fix random shutdown bug for current inverter firmware

### DIFF
--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -2,7 +2,7 @@
 # https://github.com/mkaiser/Sungrow-SHx-Inverter-Modbus-Home-Assistant
 # by Martin Kaiser
 #
-# last update: 2025-01-03
+# last update: 2025-01-09
 #
 # Note: This YAML file will only work with Home Assistant >= 2024.10
 

--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -2648,7 +2648,7 @@ automation:
           entity_id: input_select.set_sg_inverter_run_mode
         data:
           option: >
-            {% if is_state('sensor.sungrow_inverter_state', "Stop") or is_state('sensor.sungrow_inverter_state', "Shutdown") %}
+            {% if is_state('sensor.sungrow_inverter_state', "Shutdown") %}
               Shutdown
             {% else %}
               Enabled

--- a/modbus_sungrow_second_inverter_experimental.yaml
+++ b/modbus_sungrow_second_inverter_experimental.yaml
@@ -2,7 +2,7 @@
 # https://github.com/mkaiser/Sungrow-SHx-Inverter-Modbus-Home-Assistant
 # by Martin Kaiser
 #
-# last update: 2025-01-03
+# last update: 2025-01-09
 #
 # Note: This YAML file will only work with Home Assistant >= 2024.10
 

--- a/modbus_sungrow_second_inverter_experimental.yaml
+++ b/modbus_sungrow_second_inverter_experimental.yaml
@@ -2648,7 +2648,7 @@ automation:
           entity_id: input_select.set_sg_2_inverter_run_mode
         data:
           option: >
-            {% if is_state('sensor.sungrow_inverter_state_2', "Stop") or is_state('sensor.sungrow_inverter_state_2', "Shutdown") %}
+            {% if is_state('sensor.sungrow_inverter_state_2', "Shutdown") %}
               Shutdown
             {% else %}
               Enabled


### PR DESCRIPTION
With the current firmware, the plugin occasionally causes the inverter to shut down. This seems to be because the new firmware triggers sungrow_inverter_state=stop, which causes the automation to send a shutdown via Modbus.
My tests suggest that this fix solves issue #416.