### PR TITLE
Emergency Charging State Update modbus_sungrow.yaml

### DIFF
--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -2078,6 +2078,8 @@ template:
             Restarting
           {% elif ((states('sensor.system_state') |int) == 0x4000) %}
             External EMS mode
+          {% elif ((states('sensor.system_state') |int) == 0x4001) %} ### Emergency loading from grid when SOC is under BackUp SOC
+            Emergency Battery Charging            
           {% elif ((states('sensor.system_state') |int) in [0x55000,0x0100]) %}
             Fault
           {% elif ((states('sensor.system_state') |int) in [0x8000,0x0001]) %}
@@ -2088,8 +2090,6 @@ template:
             Dispatch Run
           {% elif ((states('sensor.system_state') |int) == 0x9100) %}
             Warn Running
-          {% elif ((states('sensor.system_state') |int) == 16385) %} ### Emergancy Loading from Grid when SOC is under BackUp SOC
-            Emergency Battery Charging
           {% else %}
             Unknown - should not see me! {{ (states('sensor.system_state') |int) }}
           {% endif %}

--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -2088,6 +2088,8 @@ template:
             Dispatch Run
           {% elif ((states('sensor.system_state') |int) == 0x9100) %}
             Warn Running
+          {% elif ((states('sensor.system_state') |int) == 16385) %} ### Emergancy Loading from Grid when SOC is under BackUp SOC
+            Emergency Battery Charging
           {% else %}
             Unknown - should not see me! {{ (states('sensor.system_state') |int) }}
           {% endif %}

--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -2,7 +2,7 @@
 # https://github.com/mkaiser/Sungrow-SHx-Inverter-Modbus-Home-Assistant
 # by Martin Kaiser
 #
-# last update: 2025-02-02
+# last update: 2025-02-07
 #
 # Note: This YAML file will only work with Home Assistant >= 2024.10
 


### PR DESCRIPTION
Emergency Battery Charging to BackUp SOC

BUG: In This state Battery is charging from grid, but Battery is shown as Discarging. I need some time to understood if states in line 1763 and following that charging and discarging is shown correct (now shown as discarging)