### PR TITLE
Min 10 instead of 100 for battery_max_discharge_power

### DIFF
--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -2598,7 +2598,7 @@ input_number:
 
   set_sg_battery_max_discharge_power:
     name: Max battery discharge power (W)
-    min: 100
+    min: 10
     max: 5000 # change this value according to the capability of your battery
     step: 100
 

--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -2,7 +2,7 @@
 # https://github.com/mkaiser/Sungrow-SHx-Inverter-Modbus-Home-Assistant
 # by Martin Kaiser
 #
-# last update: 2025-03-24 (2)
+# last update: 2025-03-30
 #
 # Note: This YAML file will only work with Home Assistant >= 2024.10
 #


### PR DESCRIPTION
193e5a8 for #462 does not work as expected because the input number set_sg_battery_max_discharge_power was configured with a min value of 100 and the script wants to set it to 10:

```
Logger: homeassistant.components.automation.sungrow_inverter_update_battery_max_discharge_power_input_slider_update
Source: components/automation/__init__.py:738
integration: Automation ([documentation](https://www.home-assistant.io/integrations/automation), [issues](https://github.com/home-assistant/core/issues?q=is%3Aissue+is%3Aopen+label%3A%22integration%3A+automation%22))
First occurred: 02:02:17 (6 occurrences)
Last logged: 19:18:55

    Error while executing automation automation.sungrow_inverter_update_battery_max_discharge_power_input_slider_update: Invalid value for input_number.set_sg_battery_max_discharge_power: 10.0 (range 100.0 - 5000.0)
    Error while executing automation automation.sungrow_inverter_update_battery_max_discharge_power_input_slider_update: Invalid value for input_number.set_sg_battery_max_discharge_power: 10600.0 (range 100.0 - 5000.0)
```

This simple fix addresses this 