### PR TITLE
Fix: Fix availability of PV generating (delay)

### DIFF
--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -1389,7 +1389,7 @@ template:
 
       - name: PV generating (delay)
         unique_id: sg_pv_generating_delay
-        availability: "{{ states('binary_sensor.pv_generating') }}"
+        availability: "{{ states('binary_sensor.pv_generating') not in ['unknown','unavailable'] }}"
         delay_on:
           seconds: 60
         state: "{{ states('binary_sensor.pv_generating') }}"


### PR DESCRIPTION
A template sensor requires the availability result to be either true or false. You must rewrite the availability template to verify that the source sensor has a valid state and is neither unknown nor unavailable.