### PR TITLE
Document multi-inverter dashboard usage

### DIFF
--- a/dashboards/DefaultDashboard/README.md
+++ b/dashboards/DefaultDashboard/README.md
@@ -1,18 +1,36 @@
 # Instructions
 
 1. Create a new dashboard, e.g. called "PV":
-- Home Assistant --> Settings --> Dashboards --> "Add Dashboard" 
--- Title: PV
--- click "Create"
+- Home Assistant --> Settings --> Dashboards --> "Add Dashboard" --> "New Dashboard from Scratch"
+  - Title: PV
+  - Click "Create"
 
+--> A new dashboard with the name "PV" is created
 
---> A new dashboard with the Name "PV" was created
+2. Open the dashboard and paste the content of the provided dashboard file:
+- Open the newly created dashboard "PV" (left side of HA)
+- Click the pencil icon in the top right corner to "Edit Dashboard"
+- Click the "three dots" menu and select "Raw configuration editor"
+- Delete the pre-generated sample code
+- Copy and paste the content of **dashboard.yaml** (single inverter) or **dashboard_multiple_inverters.yaml** (multi-inverter)
+- Ensure that spacing is preserved
+- Press "Save", close the editor, and press "Done"
 
-2. Open Dashboard and paste the content of the provided dashboard.yaml file
-- Open the newly creadet dashboard "PV" (left side of HA)
-- Click on the "three dots" on the top right corner and select "Edit Dashboard"
-- Move the slider and start with an empty dashboard
-- Click "Take Control"
-- Click a second time on the "three dots" on the top right corner. Now select "Raw configuration editor"
-- Copy and paste the content of dashboard.yaml. Ensure that the spacing keeps intact!
-- Save and reload page (press F5)
+---
+
+## Multi-inverter dashboard
+
+This dashboard is intended for **host/client setups** where:
+
+- inverter 1 is the host inverter (with EMS access, and optionally battery and power meter)
+- inverter 2 is a client inverter used primarily for additional PV production
+
+### The dashboard contains:
+
+- a read-only view for inverter 1, including battery, meter, grid/load, PV, and energy values  
+- a read-only view for inverter 2, focused on inverter state, PV production, AC output, and backup values  
+- an EMS control view with start/stop/status controls for both inverters, while battery and EMS controls are only shown for inverter 1  
+
+The inverter 2 view intentionally omits load power, import/export power, daily import/export energy, and battery values, as these may be unavailable or meaningless on client inverters without direct meter or battery access.
+
+**Note:** Not all multi-inverter setups use host/client mode. Retrofit setups may require a different dashboard layout.

--- a/doc/dashboard.md
+++ b/doc/dashboard.md
@@ -4,7 +4,12 @@
 
 
 ### Setup
-The folder ```/dashboards/DefaultDashboard``` in the git contains the file ```dashboard.yaml``` with a predefined dashboard showing the most relevant sungrow sensors. 
+
+
+The folder ```/dashboards/DefaultDashboard``` in the git contains predefined dashboards showing the most relevant sungrow sensors.
+
+* For single-inverter installations, use: ```dashboard.yaml```
+* For multi-inverter installations, use: ```dashboard_multiple_inverters.yaml```
 
 Navigate to folder [dashboards/DefaultDashboard](../dashboards/DefaultDashboard) and follow the instructions in [README.md](../dashboards/DefaultDashboard/README.md).
 
@@ -92,6 +97,7 @@ Edit the Energy Dashboard (Top right --> edit") and adapt the values (see screen
   <img src="images/energy_dashboard_settings_battery.drawio.svg" width="600">
   <figcaption>Energy dashboard settings for battery</figcaption>
 </figure>
+
 
 
 


### PR DESCRIPTION
- Explain when to use dashboard_multiple_inverters.yaml.

- Document that the multi-inverter dashboard assumes a host/client setup where inverter 1 provides EMS, battery, and meter-related values, while inverter 2 is primarily used for additional PV production.

- Minor edits to DefaultDashboards/README.md to reflect current Home Assistant UI when creating a new dashboard.