### PR TITLE
Add multi inverter aggregate sensors

### DIFF
--- a/additional_sensors/README.md
+++ b/additional_sensors/README.md
@@ -1,0 +1,35 @@
+# Additional sensors
+
+This folder contains optional sensors that are not part of the default setup.
+
+## `modbus_sungrow_SBR_battery.yaml`
+
+Extra Modbus settings for SBR batteries - provides per-module cell information.
+
+**Installation:** Copy the relevant sections into your `modbus_sungrow*.yaml` file.
+
+---
+
+## `multiple_inverter_aggregate_sensors.yaml`
+
+Template sensors for multi-inverter installations.
+
+These aggregate selected PV generation values across all inverter-specific entities:
+
+- Total DC Power (All Inverters)
+- Daily PV Generation (All Inverters)
+- Total PV Generation (All Inverters)
+- PV Generating (All Inverters)
+
+**Note:** The aggregate template sensors assume the default naming schemes used by this project. They match both unsuffixed single-inverter entities such as `sensor.total_dc_power` and inverter-specific entities suffixed with `_inv_1`, `_inv_2`, etc. If you have manually renamed entities or use a different naming scheme, you may need to adjust the templates accordingly.
+
+**Installation:**
+
+1. Copy `multiple_inverter_aggregate_sensors.yaml` to: `/config/templates/`
+2. Ensure your `configuration.yaml` includes:
+
+```yaml
+template: !include_dir_merge_list templates/
+```
+
+3. Restart Home Assistant (or reload template entities).

--- a/additional_sensors/multiple_inverter_aggregate_sensors.yaml
+++ b/additional_sensors/multiple_inverter_aggregate_sensors.yaml
@@ -1,0 +1,64 @@
+# Combines PV production values from multiple inverters to provide a whole-plant view.
+# Assumes default entity naming from this project (e.g. sensor.total_dc_power and/or sensor.total_dc_power_inv_1, _inv_2, ...).
+# Installation: place this file in /config/templates/
+# and ensure configuration.yaml includes:
+# template: !include_dir_merge_list templates/
+
+- sensor:
+    - name: "Total DC Power (All Inverters)"
+      unique_id: sg_total_dc_power_combined
+      unit_of_measurement: "W"
+      device_class: power
+      state_class: measurement
+      state: >-
+        {% set ns = namespace(total=0, found=false) %}
+        {% for s in states.sensor
+            if s.entity_id is match('^sensor\\.total_dc_power(_inv_[0-9]+)?$')
+            and s.state not in ['unknown', 'unavailable', 'none'] %}
+          {% set ns.total = ns.total + (s.state | float(0)) %}
+          {% set ns.found = true %}
+        {% endfor %}
+        {{ ns.total | round(2) if ns.found else 'unavailable' }}
+
+    - name: "Daily PV Generation (All Inverters)"
+      unique_id: sg_daily_pv_generation_combined
+      unit_of_measurement: "kWh"
+      device_class: energy
+      state_class: total_increasing
+      state: >-
+        {% set ns = namespace(total=0, found=false) %}
+        {% for s in states.sensor
+            if s.entity_id is match('^sensor\\.daily_pv_generation(_inv_[0-9]+)?$')
+            and s.state not in ['unknown', 'unavailable', 'none'] %}
+          {% set ns.total = ns.total + (s.state | float(0)) %}
+          {% set ns.found = true %}
+        {% endfor %}
+        {{ ns.total | round(2) if ns.found else 'unavailable' }}
+
+    - name: "Total PV Generation (All Inverters)"
+      unique_id: sg_total_pv_generation_combined
+      unit_of_measurement: "kWh"
+      device_class: energy
+      state_class: total_increasing
+      state: >-
+        {% set ns = namespace(total=0, found=false) %}
+        {% for s in states.sensor
+            if s.entity_id is match('^sensor\\.total_pv_generation(_inv_[0-9]+)?$')
+            and s.state not in ['unknown', 'unavailable', 'none'] %}
+          {% set ns.total = ns.total + (s.state | float(0)) %}
+          {% set ns.found = true %}
+        {% endfor %}
+        {{ ns.total | round(2) if ns.found else 'unavailable' }}
+
+- binary_sensor:
+    - name: "PV Generating (All Inverters)"
+      unique_id: sg_pv_generating_combined
+      state: >-
+        {% set ns = namespace(generating=false) %}
+        {% for s in states.binary_sensor
+            if s.entity_id is match('^binary_sensor\\.pv_generating(_inv_[0-9]+)?$') %}
+          {% if s.state == 'on' %}
+            {% set ns.generating = true %}
+          {% endif %}
+        {% endfor %}
+        {{ ns.generating }}

--- a/dashboards/DefaultDashboard/README.md
+++ b/dashboards/DefaultDashboard/README.md
@@ -1,18 +1,36 @@
 # Instructions
 
 1. Create a new dashboard, e.g. called "PV":
-- Home Assistant --> Settings --> Dashboards --> "Add Dashboard" 
--- Title: PV
--- click "Create"
+- Home Assistant --> Settings --> Dashboards --> "Add Dashboard" --> "New Dashboard from Scratch"
+  - Title: PV
+  - Click "Create"
 
+--> A new dashboard with the name "PV" is created
 
---> A new dashboard with the Name "PV" was created
+2. Open the dashboard and paste the content of the provided dashboard file:
+- Open the newly created dashboard "PV" (left side of HA)
+- Click the pencil icon in the top right corner to "Edit Dashboard"
+- Click the "three dots" menu and select "Raw configuration editor"
+- Delete the pre-generated sample code
+- Copy and paste the content of **dashboard.yaml** (single inverter) or **dashboard_multiple_inverters.yaml** (multi-inverter)
+- Ensure that spacing is preserved
+- Press "Save", close the editor, and press "Done"
 
-2. Open Dashboard and paste the content of the provided dashboard.yaml file
-- Open the newly creadet dashboard "PV" (left side of HA)
-- Click on the "three dots" on the top right corner and select "Edit Dashboard"
-- Move the slider and start with an empty dashboard
-- Click "Take Control"
-- Click a second time on the "three dots" on the top right corner. Now select "Raw configuration editor"
-- Copy and paste the content of dashboard.yaml. Ensure that the spacing keeps intact!
-- Save and reload page (press F5)
+---
+
+## Multi-inverter dashboard
+
+This dashboard is intended for **host/client setups** where:
+
+- inverter 1 is the host inverter (with EMS access, and optionally battery and power meter)
+- inverter 2 is a client inverter used primarily for additional PV production
+
+### The dashboard contains:
+
+- a read-only view for inverter 1, including battery, meter, grid/load, PV, and energy values  
+- a read-only view for inverter 2, focused on inverter state, PV production, AC output, and backup values  
+- an EMS control view with start/stop/status controls for both inverters, while battery and EMS controls are only shown for inverter 1  
+
+The inverter 2 view intentionally omits load power, import/export power, daily import/export energy, and battery values, as these may be unavailable or meaningless on client inverters without direct meter or battery access.
+
+**Note:** Not all multi-inverter setups use host/client mode. Retrofit setups may require a different dashboard layout.

--- a/doc/dashboard.md
+++ b/doc/dashboard.md
@@ -4,7 +4,12 @@
 
 
 ### Setup
-The folder ```/dashboards/DefaultDashboard``` in the git contains the file ```dashboard.yaml``` with a predefined dashboard showing the most relevant sungrow sensors. 
+
+
+The folder ```/dashboards/DefaultDashboard``` in the git contains predefined dashboards showing the most relevant sungrow sensors.
+
+* For single-inverter installations, use: ```dashboard.yaml```
+* For multi-inverter installations, use: ```dashboard_multiple_inverters.yaml```
 
 Navigate to folder [dashboards/DefaultDashboard](../dashboards/DefaultDashboard) and follow the instructions in [README.md](../dashboards/DefaultDashboard/README.md).
 
@@ -92,6 +97,7 @@ Edit the Energy Dashboard (Top right --> edit") and adapt the values (see screen
   <img src="images/energy_dashboard_settings_battery.drawio.svg" width="600">
   <figcaption>Energy dashboard settings for battery</figcaption>
 </figure>
+
 
 
 


### PR DESCRIPTION
Add optional template sensors for multi-inverter installations.

These provide whole-plant PV production values by aggregating inverter-specific entities for total DC power, daily PV generation, total PV generation, and PV generating status.

Also document installation and naming assumptions in additional_sensors/README.md.

I'll update the other documentation files accordingly, if this is accepted.