### PR TITLE
Fix multi-inverter filter sensor names

### DIFF
--- a/scripts/generate_second_inverter_config.py
+++ b/scripts/generate_second_inverter_config.py
@@ -51,7 +51,9 @@ _AUTOMATION_ID_LINE_RE = re.compile(
 )
 
 _NAME_LINE_RE = re.compile(
-    r"^(?P<prefix>\s*(-\s*name|alias)\s*:\s*)(?P<value>[^#\n]*?)(?P<comment>\s*(#.*)?)$"
+    r"^(?P<prefix>\s*(?:(?:-\s*)?name|alias)\s*:\s*)"
+    r"(?P<value>[^#\n]*?)"
+    r"(?P<comment>\s*(#.*)?)$"
 )
 
 _ENTITY_ID_RE = re.compile(


### PR DESCRIPTION
The multi-inverter generator suffixed "- name:" entries but did not suffix plain "name:" entries.

This left the filter sensor "Daily consumed energy (filtered)" with the same display name in all generated inverter configs causing naming collisions in the sensor registry.

This patch updates the name-matching regex so plain "name:" entries are suffixed too, and regenerate the multi-inverter YAML files.