### PR TITLE
Add device-gated "Cut PV generation" switch for SH-RT inverters (reg 31211)

### DIFF
--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -2166,7 +2166,7 @@ template:
         availability: >-
           {{ states('sensor.cut_pv_generation_raw') | is_number
              and 'RT' in states('sensor.sungrow_device_type') }}
-        is_on: "{{ states('sensor.cut_pv_generation_raw') | int(0) == 0xAA }}"
+        state: "{{ states('sensor.cut_pv_generation_raw') | int(0) == 0xAA }}"
         turn_on:
           - action: modbus.write_register
             data:

--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -1153,6 +1153,20 @@ modbus:
         state_class: measurement
         scan_interval: *scan_interval_fast
 
+      # Backing register for the "Cut PV generation" template switch (see template: switch).
+      # reg 31211 (HA address 31210): 0xAA = PV cut, 0x55 = PV allowed (normal).
+      # This is the register iSolarCloud uses to stop PV production on SH-RT inverters.
+      # Reads are harmless on any model; the template switch is gated to RT-family devices
+      # so the write path is never exposed where the register meaning is unconfirmed.
+      - name: Cut PV generation raw
+        unique_id: sg_cut_pv_generation_raw
+        device_address: !secret sungrow_modbus_device_address
+        address: &sg_reg_cut_pv_generation 31210 # reg 31211
+        input_type: holding
+        data_type: uint16
+        state_class: measurement
+        scan_interval: *scan_interval_fast
+
       - name: Battery forced charge discharge cmd raw
         unique_id: sg_battery_forced_charge_discharge_cmd_raw
         device_address: !secret sungrow_modbus_device_address
@@ -2133,6 +2147,50 @@ template:
       # hopefully this prevents accidentally setting values while browsing on the phone :)
       - name: Sungrow dashboard enable danger mode
         unique_id: uid_sungrow_dashboard_enable_danger_mode
+
+      # Cut PV generation (stop all solar production).
+      # The datasheet "PV power limitation" register 13018 is marked "Only SHT supported"
+      # and silently fails on the SH-RT family (reads 0xFFFF, writes ignored). iSolarCloud
+      # instead uses reg 31211 (HA address 31210) to stop PV on RT inverters, confirmed
+      # working on an SH10RT (firmware SAPPHIRE-H 95.12): 0xAA = cut PV, 0x55 = allow PV.
+      #
+      # Because the meaning of reg 31211 is only confirmed on the RT family, this switch is
+      # gated via `availability` to RT inverters so it is never exposed (and the write path
+      # never reachable) on models where the register could mean something else. Owners of
+      # other models that confirm the same register can widen the availability check below.
+      #
+      # Use case: cut solar during negative grid import prices so the battery charges purely
+      # from the (paid) grid.
+      - name: Cut PV generation
+        unique_id: uid_cut_pv_generation
+        availability: >-
+          {{ states('sensor.cut_pv_generation_raw') | is_number
+             and 'RT' in states('sensor.sungrow_device_type') }}
+        is_on: "{{ states('sensor.cut_pv_generation_raw') | int(0) == 0xAA }}"
+        turn_on:
+          - action: modbus.write_register
+            data:
+              hub: *sg_hub_name
+              slave: !secret sungrow_modbus_device_address
+              address: *sg_reg_cut_pv_generation
+              value: 0xAA
+          - delay:
+              milliseconds: 100
+          - action: homeassistant.update_entity
+            target:
+              entity_id: sensor.cut_pv_generation_raw
+        turn_off:
+          - action: modbus.write_register
+            data:
+              hub: *sg_hub_name
+              slave: !secret sungrow_modbus_device_address
+              address: *sg_reg_cut_pv_generation
+              value: 0x55
+          - delay:
+              milliseconds: 100
+          - action: homeassistant.update_entity
+            target:
+              entity_id: sensor.cut_pv_generation_raw
 
   ###################
   # template: button

--- a/modbus_sungrow.yaml
+++ b/modbus_sungrow.yaml
@@ -1155,7 +1155,9 @@ modbus:
 
       # Backing register for the "Cut PV generation" template switch (see template: switch).
       # reg 31211 (HA address 31210): 0xAA = PV cut, 0x55 = PV allowed (normal).
-      # This is the register iSolarCloud uses to stop PV production on SH-RT inverters.
+      # Identified by theunknown86 (issue #554) via Modbus traffic analysis of iSolarCloud —
+      # there is no named user-facing option in iSolarCloud that maps to this register, but the
+      # app writes it internally. Confirmed working on SH10RT fw SAPPHIRE-H 95.12.
       # Reads are harmless on any model; the template switch is gated to RT-family devices
       # so the write path is never exposed where the register meaning is unconfirmed.
       - name: Cut PV generation raw
@@ -2150,9 +2152,11 @@ template:
 
       # Cut PV generation (stop all solar production).
       # The datasheet "PV power limitation" register 13018 is marked "Only SHT supported"
-      # and silently fails on the SH-RT family (reads 0xFFFF, writes ignored). iSolarCloud
-      # instead uses reg 31211 (HA address 31210) to stop PV on RT inverters, confirmed
-      # working on an SH10RT (firmware SAPPHIRE-H 95.12): 0xAA = cut PV, 0x55 = allow PV.
+      # and silently fails on the SH-RT family (reads 0xFFFF, writes ignored). reg 31211
+      # (HA address 31210) was identified by theunknown86 via Modbus traffic analysis of
+      # iSolarCloud as the RT-family equivalent — no named iSolarCloud option maps to it
+      # directly. Confirmed working on SH10RT (firmware SAPPHIRE-H 95.12): 0xAA = cut PV,
+      # 0x55 = allow PV (normal).
       #
       # Because the meaning of reg 31211 is only confirmed on the RT family, this switch is
       # gated via `availability` to RT inverters so it is never exposed (and the write path


### PR DESCRIPTION
## Summary

Adds a **Cut PV generation** switch that actually works on the **SH-RT** inverter family.

The datasheet "PV power limitation" register **13018** is marked *"Only SHT supported"* and silently fails on SH-RT inverters — it reads back `0xFFFF` and writes are ignored, with no effect on PV output. iSolarCloud instead uses register **31211** (HA holding address **31210**) to stop PV production on RT inverters:

- `0xAA` = cut PV
- `0x55` = allow PV (normal)

Confirmed working live on an **SH10RT**, firmware **SAPPHIRE-H 95.12**: writing `0xAA` drove total DC power from ~5.4 kW to **0 W** in ~10 s; writing `0x55` restored PV.

## Implementation

Rather than a raw `modbus` switch (which would be writable on every model regardless of support), this is implemented as a **template switch** so it can be gated:

```yaml
availability: >-
  {{ states('sensor.cut_pv_generation_raw') | is_number
     and 'RT' in states('sensor.sungrow_device_type') }}
```

- On **non-RT** inverters the switch is **unavailable**, so the `modbus.write_register` path is never reachable — no risk of writing `0xAA` into reg 31211 on a model where its meaning is unconfirmed.
- A small backing `Cut PV generation raw` modbus sensor reads the register; reads are harmless on any model.
- Owners of other models who confirm the same register can simply widen the `availability` check.

## Use case

Cut solar during **negative grid import prices** (e.g. Amber in Australia) so the home battery charges purely from the paid grid.

## Testing

- YAML validated.
- Switch toggled both directions on an SH10RT — PV cut to 0 W and restored, `is_on` state tracked the register correctly.
- `availability` evaluates to unavailable when `sensor.sungrow_device_type` is non-RT.